### PR TITLE
Set Address as the base type of DetailedAddress

### DIFF
--- a/Source/Models/RestServiceModels.cs
+++ b/Source/Models/RestServiceModels.cs
@@ -70,7 +70,7 @@ namespace BingMapsRESTToolkit
     }
 
     [DataContract]
-    public class DetailedAddress
+    public class DetailedAddress : Address
     {
         [DataMember(Name = "countryRegionIso2", EmitDefaultValue = false)]
         public string CountryRegionIso2 { get; set; }


### PR DESCRIPTION
The Address property on a Location was not displaying all the data send by the server. This allows to get more information about the address when doing a GeocodeRequest.