### PR TITLE
Fix malformed request when requesting points on the ellipsoid

### DIFF
--- a/Source/Requests/ElevationRequest.cs
+++ b/Source/Requests/ElevationRequest.cs
@@ -240,6 +240,7 @@ namespace BingMapsRESTToolkit
             if (!GetGeoidOffset && Height == ElevationType.Ellipsoid)
             {
                 sb.AppendFormat("{0}height=ellipsoid", seperator);
+                seperator = "&";
             }
 
             sb.AppendFormat("{0}key={1}", seperator, BingMapsKey);


### PR DESCRIPTION
The separator stayed as "?" when the 'height' is the first parameter in the request, and appending the key subsequently malformed the URL

Fixes https://github.com/Microsoft/BingMapsRESTToolkit/issues/26