### PR TITLE
Add ConfigureAwait(false) to avoid context restoration and deadlocks

### DIFF
--- a/Source/Extensions/TSP Resources/BaseTspAlgorithm.cs
+++ b/Source/Extensions/TSP Resources/BaseTspAlgorithm.cs
@@ -85,7 +85,7 @@ namespace BingMapsRESTToolkit.Extensions
             {
                 //Calculate a distance matrix based on straight line distances (haversine). 
 
-                dm = await DistanceMatrix.CreateStraightLineNxNMatrix(waypoints, DistanceUnitType.Kilometers, bingMapsKey);
+                dm = await DistanceMatrix.CreateStraightLineNxNMatrix(waypoints, DistanceUnitType.Kilometers, bingMapsKey).ConfigureAwait(false);
             }
             else 
             {
@@ -110,7 +110,7 @@ namespace BingMapsRESTToolkit.Extensions
 
                 distanceMatrixRequest.Origins = waypoints;
 
-                var r = await distanceMatrixRequest.Execute();
+                var r = await distanceMatrixRequest.Execute().ConfigureAwait(false);
 
                 if (r != null)
                 {
@@ -130,7 +130,7 @@ namespace BingMapsRESTToolkit.Extensions
 
             if(dm != null)
             {
-                var solution = await Solve(dm, tspOptimization.Value);
+                var solution = await Solve(dm, tspOptimization.Value).ConfigureAwait(false);
                 solution.TspOptimization = tspOptimization.Value;
                 solution.TravelMode = travelMode.Value;
                 return solution;

--- a/Source/Extensions/TSP Resources/GeneticTspAlgorithm.cs
+++ b/Source/Extensions/TSP Resources/GeneticTspAlgorithm.cs
@@ -333,7 +333,7 @@ namespace BingMapsRESTToolkit.Extensions
                     OptimizedWeight = minWeight,
                     OptimizedWaypoints = GetOptimizedWaypoints(matrix.Origins, minTour)
                 };
-            });
+            }).ConfigureAwait(false);
         }
 
         #endregion

--- a/Source/Extensions/TravellingSalesmen.cs
+++ b/Source/Extensions/TravellingSalesmen.cs
@@ -46,7 +46,7 @@ namespace BingMapsRESTToolkit.Extensions
         /// <returns>An efficient path between all waypoints based on time or distance.</returns>
         public static async Task<TspResult> Solve(List<SimpleWaypoint> waypoints, TravelModeType? travelMode, TspOptimizationType? tspOptimization, DateTime? departureTime, string bingMapsKey)
         {
-            return await GetTspAlgorithm(waypoints).Solve(waypoints, travelMode, tspOptimization, departureTime, bingMapsKey);
+            return await GetTspAlgorithm(waypoints).Solve(waypoints, travelMode, tspOptimization, departureTime, bingMapsKey).ConfigureAwait(false);
         }
 
         ///<summary>
@@ -57,7 +57,7 @@ namespace BingMapsRESTToolkit.Extensions
         /// <returns>An efficient path between all waypoints based on time or distance.</returns>
         public static async Task<TspResult> Solve(DistanceMatrix matrix, TspOptimizationType tspOptimization)
         {
-            return await GetTspAlgorithm(matrix.Origins).Solve(matrix, tspOptimization);
+            return await GetTspAlgorithm(matrix.Origins).Solve(matrix, tspOptimization).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Internal/ServiceHelper.cs
+++ b/Source/Internal/ServiceHelper.cs
@@ -273,10 +273,10 @@ namespace BingMapsRESTToolkit
         {
             Response response = null;
 
-            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)))
+            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)).ConfigureAwait(false))
             {
                 response = ServiceHelper.DeserializeStream<Response>(responseStream);
-                return await ProcessAsyncResponse(response, remainingTimeCallback);
+                return await ProcessAsyncResponse(response, remainingTimeCallback).ConfigureAwait(false);
             }
         }
         
@@ -291,10 +291,10 @@ namespace BingMapsRESTToolkit
         {
             Response response = null;
 
-            using (var responseStream = await ServiceHelper.PostStringAsync(new Uri(requestUrl), requestBody, "application/json"))
+            using (var responseStream = await ServiceHelper.PostStringAsync(new Uri(requestUrl), requestBody, "application/json").ConfigureAwait(false))
             {
                 response = ServiceHelper.DeserializeStream<Response>(responseStream);
-                return await ProcessAsyncResponse(response, remainingTimeCallback);
+                return await ProcessAsyncResponse(response, remainingTimeCallback).ConfigureAwait(false);
             }
         }
 
@@ -310,10 +310,10 @@ namespace BingMapsRESTToolkit
         {
             Response response = null;
 
-            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)))
+            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)).ConfigureAwait(false))
             {
                 response = ServiceHelper.DeserializeStream<Response>(responseStream);
-                return await ProcessAsyncResponse<T>(response, remainingTimeCallback);
+                return await ProcessAsyncResponse<T>(response, remainingTimeCallback).ConfigureAwait(false);
             }
         }
 
@@ -330,10 +330,10 @@ namespace BingMapsRESTToolkit
         {
             Response response = null;
 
-            using (var responseStream = await ServiceHelper.PostStringAsync(new Uri(requestUrl), requestBody, "application/json"))
+            using (var responseStream = await ServiceHelper.PostStringAsync(new Uri(requestUrl), requestBody, "application/json").ConfigureAwait(false))
             {
                 response = ServiceHelper.DeserializeStream<Response>(responseStream);
-                return await ProcessAsyncResponse<T>(response, remainingTimeCallback);
+                return await ProcessAsyncResponse<T>(response, remainingTimeCallback).ConfigureAwait(false);
             }
         }
 
@@ -374,7 +374,7 @@ namespace BingMapsRESTToolkit
                     {
                         var start = DateTime.Now;
 
-                        await Task.WhenAll(taskGroup);
+                        await Task.WhenAll(taskGroup).ConfigureAwait(false);
 
                         var end = DateTime.Now;
 
@@ -385,14 +385,14 @@ namespace BingMapsRESTToolkit
                         if (i != tasks.Count - 1 && ellapsed.TotalMilliseconds < 1000)
                         {
                             //Ensure that atleast a second has passed since the last batch of requests.
-                            await Task.Delay(1000 - (int)ellapsed.TotalMilliseconds);
+                            await Task.Delay(1000 - (int)ellapsed.TotalMilliseconds).ConfigureAwait(false);
                         }
                     }
                 }
 
                 if (taskGroup.Count > 0)
                 {
-                    await Task.WhenAll(taskGroup);
+                    await Task.WhenAll(taskGroup).ConfigureAwait(false);
                 }
             });
         }
@@ -423,13 +423,13 @@ namespace BingMapsRESTToolkit
                     {
                         var status = response.ResourceSets[0].Resources[0] as AsyncStatus;
 
-                        status = await ServiceHelper.ProcessAsyncStatus(status, remainingTimeCallback);
+                        status = await ServiceHelper.ProcessAsyncStatus(status, remainingTimeCallback).ConfigureAwait(false);
 
                         if (status != null && status.IsCompleted && !string.IsNullOrEmpty(status.ResultUrl))
                         {
                             try
                             {
-                                using (var resultStream = await ServiceHelper.GetStreamAsync(new Uri(status.ResultUrl)))
+                                using (var resultStream = await ServiceHelper.GetStreamAsync(new Uri(status.ResultUrl)).ConfigureAwait(false))
                                 {
                                     return ServiceHelper.DeserializeStream<Response>(resultStream);
                                 }
@@ -472,13 +472,13 @@ namespace BingMapsRESTToolkit
                     {
                         var status = response.ResourceSets[0].Resources[0] as AsyncStatus;
 
-                        status = await ServiceHelper.ProcessAsyncStatus(status, remainingTimeCallback);
+                        status = await ServiceHelper.ProcessAsyncStatus(status, remainingTimeCallback).ConfigureAwait(false);
 
                         if (status != null && status.IsCompleted && !string.IsNullOrEmpty(status.ResultUrl))
                         {
                             try
                             {
-                                using (var resultStream = await ServiceHelper.GetStreamAsync(new Uri(status.ResultUrl)))
+                                using (var resultStream = await ServiceHelper.GetStreamAsync(new Uri(status.ResultUrl)).ConfigureAwait(false))
                                 {
                                     var resource = ServiceHelper.DeserializeStream<T>(resultStream);
                                     response.ResourceSets[0].Resources[0] = resource;
@@ -521,9 +521,9 @@ namespace BingMapsRESTToolkit
                 remainingTimeCallback?.Invoke(status.CallbackInSeconds);
 
                 //Wait remaining seconds.
-                await Task.Delay(TimeSpan.FromSeconds(status.CallbackInSeconds));
+                await Task.Delay(TimeSpan.FromSeconds(status.CallbackInSeconds)).ConfigureAwait(false);
 
-                status = await ServiceHelper.MonitorAsyncStatus(statusUrl, 0, remainingTimeCallback);
+                status = await ServiceHelper.MonitorAsyncStatus(statusUrl, 0, remainingTimeCallback).ConfigureAwait(false);
             }
             else
             {
@@ -562,7 +562,7 @@ namespace BingMapsRESTToolkit
 
             try
             {
-                using (var rs = await ServiceHelper.GetStreamAsync(statusUrl))
+                using (var rs = await ServiceHelper.GetStreamAsync(statusUrl).ConfigureAwait(false))
                 {
                     var r = ServiceHelper.DeserializeStream<Response>(rs);
 
@@ -581,8 +581,8 @@ namespace BingMapsRESTToolkit
                                 remainingTimeCallback?.Invoke(status.CallbackInSeconds);
 
                                 //Wait remaining seconds.
-                                await Task.Delay(TimeSpan.FromSeconds(status.CallbackInSeconds));
-                                return await MonitorAsyncStatus(statusUrl, 0, remainingTimeCallback);
+                                await Task.Delay(TimeSpan.FromSeconds(status.CallbackInSeconds)).ConfigureAwait(false);
+                                return await MonitorAsyncStatus(statusUrl, 0, remainingTimeCallback).ConfigureAwait(false);
                             }
                         }
                     }
@@ -594,8 +594,8 @@ namespace BingMapsRESTToolkit
                 if (failedTries < MaxStatusCheckRetries)
                 {
                     //Wait some time and try again.
-                    await Task.Delay(TimeSpan.FromSeconds(StatusCheckRetryDelay));
-                    return await MonitorAsyncStatus(statusUrl, failedTries + 1, remainingTimeCallback);
+                    await Task.Delay(TimeSpan.FromSeconds(StatusCheckRetryDelay)).ConfigureAwait(false);
+                    return await MonitorAsyncStatus(statusUrl, failedTries + 1, remainingTimeCallback).ConfigureAwait(false);
                 }
                 else
                 {

--- a/Source/Internal/TruckDistanceMatrixGenerator.cs
+++ b/Source/Internal/TruckDistanceMatrixGenerator.cs
@@ -87,7 +87,7 @@ namespace BingMapsRESTToolkit.Extensions
             MatrixCells = new List<DistanceMatrixCell>();
             
             //Calculate the first cell on it's own to verify that the request can be made. If it fails, do not proceed.
-            var firstResponse = await CalculateTruckRoute(request.Origins[0], request.Destinations[0], 0, request);
+            var firstResponse = await CalculateTruckRoute(request.Origins[0], request.Destinations[0], 0, request).ConfigureAwait(false);
 
             if(firstResponse != null && firstResponse.ErrorDetails != null && firstResponse.ErrorDetails.Length > 0){
                 return firstResponse;
@@ -152,7 +152,7 @@ namespace BingMapsRESTToolkit.Extensions
                 }
             }
 
-            await ServiceHelper.WhenAllTaskLimiter(cellTasks);
+            await ServiceHelper.WhenAllTaskLimiter(cellTasks).ConfigureAwait(false);
 
             var dm = new DistanceMatrix()
             {
@@ -202,7 +202,7 @@ namespace BingMapsRESTToolkit.Extensions
 
             try
             {
-                var response = await CalculateTruckRoute(dmRequest.Origins[originIdx], dmRequest.Destinations[destIdx], timeIdx, dmRequest);
+                var response = await CalculateTruckRoute(dmRequest.Origins[originIdx], dmRequest.Destinations[destIdx], timeIdx, dmRequest).ConfigureAwait(false);
 
                 if (response != null && response.ResourceSets != null && response.ResourceSets.Length > 0 &&
                         response.ResourceSets[0].Resources != null && response.ResourceSets[0].Resources.Length > 0)
@@ -272,7 +272,7 @@ namespace BingMapsRESTToolkit.Extensions
                 request.RouteOptions.Optimize = RouteOptimizationType.TimeWithTraffic;
             }
 
-            return await request.Execute();
+            return await request.Execute().ConfigureAwait(false);
         }
 
         #endregion

--- a/Source/Models/ResponseModels/DistanceMatrix.cs
+++ b/Source/Models/ResponseModels/DistanceMatrix.cs
@@ -488,7 +488,7 @@ namespace BingMapsRESTToolkit
 
             if (!string.IsNullOrEmpty(bingMapsKey))
             {
-                await SimpleWaypoint.TryGeocodeWaypoints(waypoints, bingMapsKey);
+                await SimpleWaypoint.TryGeocodeWaypoints(waypoints, bingMapsKey).ConfigureAwait(false);
             }
 
             var numWaypoints = waypoints.Count;
@@ -513,7 +513,7 @@ namespace BingMapsRESTToolkit
                         TravelDistance = distance
                     };
                 }
-            }));
+            })).ConfigureAwait(false);
 
             return new DistanceMatrix()
             {

--- a/Source/Models/SimpleWaypoint.cs
+++ b/Source/Models/SimpleWaypoint.cs
@@ -227,7 +227,7 @@ namespace BingMapsRESTToolkit
                 BingMapsKey = bingMapsKey
             };
 
-            await TryGeocode(waypoint, request);
+            await TryGeocode(waypoint, request).ConfigureAwait(false);
         }
         
         /// <summary>
@@ -255,7 +255,7 @@ namespace BingMapsRESTToolkit
 
                 try
                 {
-                    var r = await ServiceManager.GetResponseAsync(request);
+                    var r = await ServiceManager.GetResponseAsync(request).ConfigureAwait(false);
 
                     if (r != null && r.ResourceSets != null &&
                         r.ResourceSets.Length > 0 &&
@@ -294,7 +294,7 @@ namespace BingMapsRESTToolkit
 
             if (geocodeTasks.Count > 0)
             {
-                await ServiceHelper.WhenAllTaskLimiter(geocodeTasks);
+                await ServiceHelper.WhenAllTaskLimiter(geocodeTasks).ConfigureAwait(false);
             }
         }
 
@@ -311,7 +311,7 @@ namespace BingMapsRESTToolkit
                 BingMapsKey = bingMapsKey
             };
 
-            await TryGeocodeWaypoints(waypoints, request);
+            await TryGeocodeWaypoints(waypoints, request).ConfigureAwait(false);
         }
 
         #endregion

--- a/Source/Requests/AutosuggestRequest.cs
+++ b/Source/Requests/AutosuggestRequest.cs
@@ -110,7 +110,7 @@ namespace BingMapsRESTToolkit
         {
             Stream responseStream = null;
 
-            responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl()));
+            responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl())).ConfigureAwait(false);
 
 
             if (responseStream != null)

--- a/Source/Requests/BaseRestRequest.cs
+++ b/Source/Requests/BaseRestRequest.cs
@@ -106,7 +106,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public virtual async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace BingMapsRESTToolkit
         {
             Response r = null;
 
-            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl())))
+            using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl())).ConfigureAwait(false))
             {
                 r = ServiceHelper.DeserializeStream<Response>(responseStream);
             }

--- a/Source/Requests/DistanceMatrixRequest.cs
+++ b/Source/Requests/DistanceMatrixRequest.cs
@@ -130,7 +130,7 @@ namespace BingMapsRESTToolkit
         /// </summary>
         /// <returns>A response containing the requested distance matrix.</returns>
         public override async Task<Response> Execute() {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -143,12 +143,12 @@ namespace BingMapsRESTToolkit
             if (TravelMode != TravelModeType.Truck)
             {
                 //Make sure all origins and destinations are geocoded.
-                await GeocodeWaypoints();
+                await GeocodeWaypoints().ConfigureAwait(false);
 
                 var requestUrl = GetRequestUrl();
                 var requestBody = GetPostRequestBody();
 
-                var response = await ServiceHelper.MakeAsyncPostRequest<DistanceMatrix>(requestUrl, requestBody, remainingTimeCallback);
+                var response = await ServiceHelper.MakeAsyncPostRequest<DistanceMatrix>(requestUrl, requestBody, remainingTimeCallback).ConfigureAwait(false);
 
                 var dm = response.ResourceSets[0].Resources[0] as DistanceMatrix;
 
@@ -174,7 +174,7 @@ namespace BingMapsRESTToolkit
                 var requestUrl = GetRequestUrl();
 
                 //Generate truck routing based distnace matrix by wrapping routing service.
-                return await new Extensions.TruckDistanceMatrixGenerator().Calculate(this, remainingTimeCallback);              
+                return await new Extensions.TruckDistanceMatrixGenerator().Calculate(this, remainingTimeCallback).ConfigureAwait(false);
             }
 
             return null;           
@@ -189,13 +189,13 @@ namespace BingMapsRESTToolkit
             //Ensure all the origins are geocoded.
             if (Origins != null)
             {
-                await SimpleWaypoint.TryGeocodeWaypoints(Origins, this);
+                await SimpleWaypoint.TryGeocodeWaypoints(Origins, this).ConfigureAwait(false);
             }
 
             //Ensure all the destinations are geocoded.
             if (Destinations != null)
             {
-                await SimpleWaypoint.TryGeocodeWaypoints(Destinations, this);
+                await SimpleWaypoint.TryGeocodeWaypoints(Destinations, this).ConfigureAwait(false);
             }
         }
 
@@ -207,7 +207,7 @@ namespace BingMapsRESTToolkit
         {
             if(this.Origins != null && this.Origins.Count > 0)
             //Make sure all origins and destinations are geocoded.
-            await GeocodeWaypoints();
+            await GeocodeWaypoints().ConfigureAwait(false);
 
             var dm = new DistanceMatrix()
             {

--- a/Source/Requests/ElevationRequest.cs
+++ b/Source/Requests/ElevationRequest.cs
@@ -146,7 +146,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public override async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -161,11 +161,11 @@ namespace BingMapsRESTToolkit
             if (Points != null && Points.Count > 50)
             {
                 //Make a post request when there are more than 50 points as there is a risk of URL becoming too large for a GET request.
-                responseStream = await ServiceHelper.PostStringAsync(new Uri(GetPostRequestUrl()), GetPointsAsString(), null);
+                responseStream = await ServiceHelper.PostStringAsync(new Uri(GetPostRequestUrl()), GetPointsAsString(), null).ConfigureAwait(false);
             }
             else
             {
-                responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl()));
+                responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl())).ConfigureAwait(false);
             }
 
             if (responseStream != null)

--- a/Source/Requests/ImageryRequest.cs
+++ b/Source/Requests/ImageryRequest.cs
@@ -213,7 +213,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public override async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -230,11 +230,11 @@ namespace BingMapsRESTToolkit
             if (Pushpins != null && Pushpins.Count > 18)
             {
                 //Make a post request when there are more than 18 pushpins as there is a risk of URL becoming too large for a GET request.
-                responseStream = await ServiceHelper.PostStringAsync(new Uri(GetPostRequestUrl()), GetPushpinsAsString(), null);
+                responseStream = await ServiceHelper.PostStringAsync(new Uri(GetPostRequestUrl()), GetPushpinsAsString(), null).ConfigureAwait(false);
             }
             else
             {
-                responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl()));
+                responseStream = await ServiceHelper.GetStreamAsync(new Uri(GetRequestUrl())).ConfigureAwait(false);
             }
 
             if (responseStream != null)

--- a/Source/Requests/IsochroneRequest.cs
+++ b/Source/Requests/IsochroneRequest.cs
@@ -110,7 +110,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public override async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace BingMapsRESTToolkit
         {
             var requestUrl = GetRequestUrl();
 
-            return await ServiceHelper.MakeAsyncGetRequest(requestUrl, remainingTimeCallback);
+            return await ServiceHelper.MakeAsyncGetRequest(requestUrl, remainingTimeCallback).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Requests/RouteRequest.cs
+++ b/Source/Requests/RouteRequest.cs
@@ -112,7 +112,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public override async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace BingMapsRESTToolkit
                 //Check to see if the waypoints have changed since they were last optimized. 
                 if (waypointsHash != wpHash || string.Compare(optimizationOptionHash, optionHash) != 0)
                 {
-                    var tspResult = await TravellingSalesmen.Solve(Waypoints, mode, WaypointOptimization, depart, BingMapsKey);
+                    var tspResult = await TravellingSalesmen.Solve(Waypoints, mode, WaypointOptimization, depart, BingMapsKey).ConfigureAwait(false);
                     Waypoints = tspResult.OptimizedWaypoints;
 
                     //Update the stored hashes to prevent unneeded optimizations in the future if not needed.
@@ -174,13 +174,13 @@ namespace BingMapsRESTToolkit
                 {
                     var requestBody = GetTruckPostRequestBody(startIdx, out endIdx);
 
-                    response = await ServiceHelper.MakeAsyncPostRequest(requestUrl, requestBody, remainingTimeCallback);
+                    response = await ServiceHelper.MakeAsyncPostRequest(requestUrl, requestBody, remainingTimeCallback).ConfigureAwait(false);
                 }
                 else
                 {
                     remainingTimeCallback?.Invoke(1);
 
-                    using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)))
+                    using (var responseStream = await ServiceHelper.GetStreamAsync(new Uri(requestUrl)).ConfigureAwait(false))
                     {
                         response = ServiceHelper.DeserializeStream<Response>(responseStream);
                     }
@@ -255,7 +255,7 @@ namespace BingMapsRESTToolkit
 
                 if (routeTasks.Count > 0)
                 {
-                    await ServiceHelper.WhenAllTaskLimiter(routeTasks);
+                    await ServiceHelper.WhenAllTaskLimiter(routeTasks).ConfigureAwait(false);
                 }
 
                 try
@@ -270,7 +270,7 @@ namespace BingMapsRESTToolkit
                                 {
                                     Resources = new Resource[]
                                     {
-                                        await MergeRoutes(routes)
+                                        await MergeRoutes(routes).ConfigureAwait(false)
                                     }
                                 }
                         }

--- a/Source/Requests/SnapToRoadRequest.cs
+++ b/Source/Requests/SnapToRoadRequest.cs
@@ -111,7 +111,7 @@ namespace BingMapsRESTToolkit
         /// <returns>A response containing the requested data.</returns>
         public override async Task<Response> Execute()
         {
-            return await this.Execute(null);
+            return await this.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace BingMapsRESTToolkit
             var requestUrl = GetRequestUrl();
             var requestBody = GetPostRequestBody();
 
-            return await ServiceHelper.MakeAsyncPostRequest<Route>(requestUrl, requestBody, remainingTimeCallback);
+            return await ServiceHelper.MakeAsyncPostRequest<Route>(requestUrl, requestBody, remainingTimeCallback).ConfigureAwait(false);
         }
         
         /// <summary>

--- a/Source/ServiceManager.cs
+++ b/Source/ServiceManager.cs
@@ -64,7 +64,7 @@ namespace BingMapsRESTToolkit
         /// <returns>The response from the REST service.</returns>
         public static async Task<Response> GetResponseAsync(BaseRestRequest request)
         {
-            return await request.Execute(null);
+            return await request.Execute(null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace BingMapsRESTToolkit
         /// <returns>The response from the REST service.</returns>
         public static async Task<Response> GetResponseAsync(BaseRestRequest request, Action<int> remainingTimeCallback)
         {
-            return await request.Execute(remainingTimeCallback);
+            return await request.Execute(remainingTimeCallback).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,16 +94,16 @@ namespace BingMapsRESTToolkit
                 if (r.Pushpins != null && (r.Pushpins.Count > 18 || r.Style != null))
                 {
                     //Make a post request when there are more than 18 pushpins as there is a risk of URL becoming too large for a GET request.
-                    return await ServiceHelper.PostStringAsync(new Uri(r.GetPostRequestUrl()), r.GetPushpinsAsString(), null);
+                    return await ServiceHelper.PostStringAsync(new Uri(r.GetPostRequestUrl()), r.GetPushpinsAsString(), null).ConfigureAwait(false);
                 }
                 else
                 {
-                    return await ServiceHelper.GetStreamAsync(new Uri(r.GetRequestUrl()));
+                    return await ServiceHelper.GetStreamAsync(new Uri(r.GetRequestUrl())).ConfigureAwait(false);
                 }
             }
             else
             {
-                return await ServiceHelper.GetStreamAsync(new Uri(imageryRequest.GetRequestUrl()));
+                return await ServiceHelper.GetStreamAsync(new Uri(imageryRequest.GetRequestUrl())).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Currently some calls in this library can deadlock when used in a synchronous context (sync over async).
This adds ConfigureAwait(false) on all awaited calls to avoid the issue.

This should solve #22 


