### PR TITLE
Add TransitStop data contract to route response

### DIFF
--- a/Source/BingMapsRESTToolkit.Standard/BingMapsRESTToolkit.Standard.csproj
+++ b/Source/BingMapsRESTToolkit.Standard/BingMapsRESTToolkit.Standard.csproj
@@ -114,6 +114,7 @@
     <Compile Include="..\Models\ResponseModels\StaticMapMetadata.cs" Link="Models\ResponseModels\StaticMapMetadata.cs" />
     <Compile Include="..\Models\ResponseModels\TrafficIncident.cs" Link="Models\ResponseModels\TrafficIncident.cs" />
     <Compile Include="..\Models\ResponseModels\TransitLine.cs" Link="Models\ResponseModels\TransitLine.cs" />
+    <Compile Include="..\Models\ResponseModels\TransitStop.cs" Link="Models\ResponseModels\TransitStop.cs" />
     <Compile Include="..\Models\ResponseModels\Warning.cs" Link="Models\ResponseModels\Warning.cs" />
     <Compile Include="..\Models\ResponseModels\Waypoint.cs" Link="Models\ResponseModels\Waypoint.cs" />
 

--- a/Source/BingMapsRESTToolkit.csproj
+++ b/Source/BingMapsRESTToolkit.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Models\ResponseModels\RESTTimeZone.cs" />
     <Compile Include="Models\ResponseModels\TimeZoneResponse.cs" />
     <Compile Include="Models\ResponseModels\TrafficIncident.cs" />
+    <Compile Include="Models\ResponseModels\TransitStop.cs" />
     <Compile Include="Models\ResponseModels\TransitLine.cs" />
     <Compile Include="Models\CircularView.cs" />
     <Compile Include="Models\ResponseModels\Warning.cs" />

--- a/Source/Models/ResponseModels/ItineraryItem.cs
+++ b/Source/Models/ResponseModels/ItineraryItem.cs
@@ -159,6 +159,12 @@ namespace BingMapsRESTToolkit
         public TransitLine TransitLine { get; set; }
 
         /// <summary>
+        /// The list of transit stops associated with the itinerary item.
+        /// </summary>
+        [DataMember(Name = "transitStops", EmitDefaultValue = false)]
+        public TransitStop[] TransitStops { get; set; }
+
+        /// <summary>
         /// The ID assigned to the transit stop by the transit agency.
         /// </summary>
         [DataMember(Name = "transitStopId", EmitDefaultValue = false)]

--- a/Source/Models/ResponseModels/TransitStop.cs
+++ b/Source/Models/ResponseModels/TransitStop.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Copyright(c) 2017 Microsoft Corporation. All rights reserved. 
+ * 
+ * This code is licensed under the MIT License (MIT). 
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do 
+ * so, subject to the following conditions: 
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. 
+*/
+
+using System.Runtime.Serialization;
+
+namespace BingMapsRESTToolkit
+{
+    /// <summary>
+    /// Information about the transit stop associated with the itinerary item.
+    /// </summary>
+    [DataContract]
+    public class TransitStop
+    {
+        /// <summary>
+        /// The ID associated with the transit agency.
+        /// </summary>
+        [DataMember(Name = "stopId", EmitDefaultValue = false)]
+        public int StopId { get; set; }
+
+        /// <summary>
+        /// The name of a transit stop.        
+        /// </summary>
+        [DataMember(Name = "stopName", EmitDefaultValue = false)]
+        public string StopName { get; set; }
+
+        /// <summary>
+        /// The coordinates of a point on the Earth. A point contains Latitude and Longitude elements.
+        /// </summary>
+        [DataMember(Name = "position", EmitDefaultValue = false)]
+        public Point Position { get; set; }
+    }
+}


### PR DESCRIPTION
Bing REST services provide data about route transit stops, but actual data contracts lack of this info.