### PR TITLE
Add missing avoid types for calculating routes

### DIFF
--- a/Source/Enums/AvoidType.cs
+++ b/Source/Enums/AvoidType.cs
@@ -30,6 +30,16 @@ namespace BingMapsRESTToolkit
     public enum AvoidType
     {
         /// <summary>
+        /// Avoids crossing country borders in the route.
+        /// </summary>
+        BorderCrossing,
+
+        /// <summary>
+        /// Avoids the use of ferries in the route.
+        /// </summary>
+        Ferry,
+
+        /// <summary>
         /// Avoids the use of highways in the route. 
         /// </summary>
         Highways,


### PR DESCRIPTION
Add avoid types per documentation for calculating routes: ferry, border crossing.  Addition of avoid types of "ferry" and "borderCrossing" per documentation: https://docs.microsoft.com/en-us/bingmaps/rest-services/routes/calculate-a-route