### PR TITLE
Fix globalization issues in double handling

### DIFF
--- a/Samples/WPF/TravellingSalesmenRouteSample/MainWindow.xaml.cs
+++ b/Samples/WPF/TravellingSalesmenRouteSample/MainWindow.xaml.cs
@@ -185,7 +185,8 @@ namespace TravellingSalesmenRouteSample
 
                     if (m.Success)
                     {
-                        waypoints.Add(new SimpleWaypoint(double.Parse(m.Groups[1].Value), double.Parse(m.Groups[3].Value)));
+                        waypoints.Add(new SimpleWaypoint(double.Parse(m.Groups[1].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture),
+                            double.Parse(m.Groups[3].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture)));
                     }
                     else
                     {

--- a/Source/Models/ResponseModels/Warning.cs
+++ b/Source/Models/ResponseModels/Warning.cs
@@ -52,7 +52,8 @@ namespace BingMapsRESTToolkit
                     double lat;
                     double lon;
 
-                    if (latLng.Length >= 2 && double.TryParse(latLng[0], out lat) && double.TryParse(latLng[1], out lon))
+                    if (latLng.Length >= 2 && double.TryParse(latLng[0], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out lat) 
+                        && double.TryParse(latLng[1], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out lon))
                     {
                         return new Coordinate(lat, lon);
                     }
@@ -68,7 +69,7 @@ namespace BingMapsRESTToolkit
                 }
                 else
                 {
-                    Origin = string.Format("{0},{1}", value.Latitude, value.Longitude);
+                    Origin = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0},{1}", value.Latitude, value.Longitude);
                 }
             }
         }
@@ -120,7 +121,7 @@ namespace BingMapsRESTToolkit
                 }
                 else
                 {
-                    To = string.Format("{0},{1}", value.Latitude, value.Longitude);
+                    To = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0},{1}", value.Latitude, value.Longitude);
                 }
             }
         }

--- a/Source/Requests/AutosuggestRequest.cs
+++ b/Source/Requests/AutosuggestRequest.cs
@@ -50,7 +50,7 @@ namespace BingMapsRESTToolkit
         /// Return Comma-separated list of Lat,Lon,Radius
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => string.Format("{0},{1},{2}", Latitude.ToString(), Longitude.ToString(), Radius.ToString());
+        public override string ToString() => string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0},{1},{2}", Latitude.ToString(), Longitude.ToString(), Radius.ToString());
     }
 
 

--- a/Source/Requests/IsochroneRequest.cs
+++ b/Source/Requests/IsochroneRequest.cs
@@ -192,7 +192,7 @@ namespace BingMapsRESTToolkit
                     throw new Exception("Distance based isochrones are not supported for transit travel mode. Use maxTime.");
                 }
 
-                sb.AppendFormat("&maxDistance={0}&distanceUnit={1}", MaxDistance, EnumHelper.DistanceUnitTypeToString(DistanceUnit));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "&maxDistance={0}&distanceUnit={1}", MaxDistance, EnumHelper.DistanceUnitTypeToString(DistanceUnit));
 
                 //Can only optimize based on distance when generating distance based isochrones.
                 if (Optimize != RouteOptimizationType.Distance)

--- a/Source/Requests/LocationRecogRequest.cs
+++ b/Source/Requests/LocationRecogRequest.cs
@@ -233,7 +233,7 @@ namespace BingMapsRESTToolkit
 
             List<string> param_list = new List<string>
             {
-                string.Format("r={0}", Radius.ToString()),
+                string.Format("r={0}", Radius.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 string.Format("top={0}", Top.ToString()),
                 string.Format("distanceUnit={0}", du),
                 string.Format("verboseplacenames={0}", VerbosePlaceNames.ToString().ToLower()),

--- a/Source/Requests/RouteRequest.cs
+++ b/Source/Requests/RouteRequest.cs
@@ -678,32 +678,32 @@ namespace BingMapsRESTToolkit
 
                     if (RouteOptions.VehicleSpec.VehicleHeight > 0)
                     {
-                        sb.AppendFormat(",\"vehicleHeight\":{0}", RouteOptions.VehicleSpec.VehicleHeight);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleHeight\":{0}", RouteOptions.VehicleSpec.VehicleHeight);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleWidth > 0)
                     {
-                        sb.AppendFormat(",\"vehicleWidth\":{0}", RouteOptions.VehicleSpec.VehicleWidth);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleWidth\":{0}", RouteOptions.VehicleSpec.VehicleWidth);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleLength > 0)
                     {
-                        sb.AppendFormat(",\"vehicleLength\":{0}", RouteOptions.VehicleSpec.VehicleLength);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleLength\":{0}", RouteOptions.VehicleSpec.VehicleLength);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleWeight > 0)
                     {
-                        sb.AppendFormat(",\"vehicleWeight\":{0}", RouteOptions.VehicleSpec.VehicleWeight);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleWeight\":{0}", RouteOptions.VehicleSpec.VehicleWeight);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleMaxGradient > 0)
                     {
-                        sb.AppendFormat(",\"vehicleMaxGradient\":{0}", RouteOptions.VehicleSpec.VehicleMaxGradient);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleMaxGradient\":{0}", RouteOptions.VehicleSpec.VehicleMaxGradient);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleMinTurnRadius > 0)
                     {
-                        sb.AppendFormat(",\"vehicleMinTurnRadius\":{0}", RouteOptions.VehicleSpec.VehicleMinTurnRadius);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, ",\"vehicleMinTurnRadius\":{0}", RouteOptions.VehicleSpec.VehicleMinTurnRadius);
                     }
 
                     if (RouteOptions.VehicleSpec.VehicleTrailers > 0)


### PR DESCRIPTION
There are a few globalization issues in handling double values when the locale uses commas as decimal separators. This pull request uses System.Globalization.CultureInfo.InvariantCulture to ensure values are parsed and formatted using decimal points.